### PR TITLE
Fix typos/links, add conclusions, rm references tab

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ Our overarching goals of this workshop is as follows:
 * Learn about Prompt Engineering and how to leverage a local LLM in daily tasks.
 
 !!! tip
-    working with AI is all about exploration and hands-on engagement. These labs are designed to give you everything you need to get started — so you can collaborate, experiment, and learn together. Don’t hesitate to ask questions, raise your hand, and connect with other participants.
+    Working with AI is all about exploration and hands-on engagement. These labs are designed to give you everything you need to get started — so you can collaborate, experiment, and learn together. Don’t hesitate to ask questions, raise your hand, and connect with other participants.
 
 ## Agenda
 

--- a/docs/lab-1.5/README.md
+++ b/docs/lab-1.5/README.md
@@ -4,6 +4,8 @@ description: Set up Open-WebUI to start using an LLM locally
 logo: images/ibm-blue-background.png
 ---
 
+## Setup
+
 Let's start by configuring [Open-WebUI](../pre-work/README.md#installing-open-webui) and `ollama` to talk to one another. The following screenshots will be from a Mac, but this should be similar on Windows and Linux.
 
 First, if you haven't already, download the Granite 3.1 model. Make sure that `ollama` is running in the background (you may have to run `ollama serve` in its own terminal depending on how you installed it) and in another terminal run the following command:
@@ -25,10 +27,11 @@ Click *Getting Started*. Fill out the next screen and click the *Create Admin Ac
 
 ![user setup screen](../images/openwebui_user_setup_screen.png)
 
-You should see the Open-WebUI main page now, with `granite3.1-dense:latest` right there in
-the center!
+You should see the Open-WebUI main page now, with `granite3.1-dense:latest` right there in the center!
 
 ![main screen](../images/openwebui_main_screen.png)
+
+## Testing the Connection
 
 Test it out! I like asking the question, "Who is Batman?" as a sanity check. Every LLM should know who Batman is.
 
@@ -38,4 +41,6 @@ The first response may take a minute to process. This is because `ollama` is spi
 
 You may notice that your answer is slighty different then the screen shot above. This is expected and nothing to worry about!
 
-**Congratulations!** Now you have Open-WebUI running and it's configured to work with `granite3.1-dense` and `ollama`. Move on to the next lab and have a chat with your model!
+## Conclusion
+
+**Congratulations!** Now you have Open-WebUI running and it's configured to work with `granite3.1-dense` and `ollama`. Move on to [Lab 2](/docs/lab-2/README.md) and have a chat with your model!

--- a/docs/lab-1.5/README.md
+++ b/docs/lab-1.5/README.md
@@ -43,4 +43,4 @@ You may notice that your answer is slighty different then the screen shot above.
 
 ## Conclusion
 
-**Congratulations!** Now you have Open-WebUI running and it's configured to work with `granite3.1-dense` and `ollama`. Move on to [Lab 2](/docs/lab-2/README.md) and have a chat with your model!
+**Congratulations!** Now you have Open-WebUI running and it's configured to work with `granite3.1-dense` and `ollama`. Move on to [Lab 2](https://ibm.github.io/opensource-ai-workshop/lab-2/) and have a chat with your model!

--- a/docs/lab-1/README.md
+++ b/docs/lab-1/README.md
@@ -4,6 +4,8 @@ description: Set up AnythingLLM to start using an LLM locally
 logo: images/ibm-blue-background.png
 ---
 
+## Setup
+
 Let's start by configuring [AnythingLLM installed](../pre-work/README.md#anythingllm) and `ollama` to talk to one another. The following screenshots will be from a Mac, but this should be similar on Windows and Linux.
 
 First, if you haven't already, download the Granite 3.1 model. Make sure that `ollama` is running in the background (you may have to run `ollama serve` in its own terminal depending on how you installed it) and in another terminal run the following command:
@@ -33,6 +35,8 @@ Give it a name (e.g. the event you're attending today):
 
 ![naming new workspace](../images/anythingllm_naming_workspace.png)
 
+## Testing the Connection
+
 Now, let's test our connection AnythingLLM! I like asking the question, "Who is Batman?" as a sanity check. Every LLM should know who Batman is.
 
 The first response may take a minute to process. This is because `ollama` is spinning up to serve the model. Subsequent responses should be much faster.
@@ -41,4 +45,6 @@ The first response may take a minute to process. This is because `ollama` is spi
 
 You may notice that your answer is slighty different then the screen shot above. This is expected and nothing to worry about!
 
-**Congratulations!** Now you have AnythingLLM running and it's configured to work with `granite3.1-dense` and `ollama`. Move on to the next lab and have a chat with your model!
+## Conclusion
+
+**Congratulations!** Now you have AnythingLLM running and it's configured to work with `granite3.1-dense` and `ollama`. Move on to [Lab 2](/docs/lab-2/README.md) and have a chat with your model!

--- a/docs/lab-1/README.md
+++ b/docs/lab-1/README.md
@@ -47,4 +47,4 @@ You may notice that your answer is slighty different then the screen shot above.
 
 ## Conclusion
 
-**Congratulations!** Now you have AnythingLLM running and it's configured to work with `granite3.1-dense` and `ollama`. Move on to [Lab 2](/docs/lab-2/README.md) and have a chat with your model!
+**Congratulations!** Now you have AnythingLLM running and it's configured to work with `granite3.1-dense` and `ollama`. Move on to [Lab 2](https://ibm.github.io/opensource-ai-workshop/lab-2/) and have a chat with your model!

--- a/docs/lab-2/README.md
+++ b/docs/lab-2/README.md
@@ -104,4 +104,4 @@ in Batman's extensive history.
 
 Spend as much time as you want asking your LLM about anything about any topic and exploring how you can alter its output to provide you with more interesting or satisfying responses.
 
-When you feel acquainted with your model, move on to [Lab 3](/docs/lab-3/README.md) to learn about Prompt Engineering.
+When you are acquainted with your model, move on to [Lab 3](https://ibm.github.io/opensource-ai-workshop/lab-3/) to learn about Prompt Engineering.

--- a/docs/lab-2/README.md
+++ b/docs/lab-2/README.md
@@ -4,7 +4,9 @@ description: Get acquainted with your local LLM
 logo: images/ibm-blue-background.png
 ---
 
-It's time for the fun exploration part your Prompt Engineering (PE) journey.
+It's time for the fun exploration part your Prompt Engineering (PE) journey. In this lab, you're encouraged to spend as much time as you can chatting with the model, especially if you have little experience doing so. Keep some questions in mind: can you make it speak in a different tone? Can it provide a recipe for a cake or a poem about technology? Is it self-aware?
+
+## Chatting with the Model
 
 Open a brand _new_ Workspace in AnythingLLM (or Open-WebUI) called "Learning Prompt Engineering".
 
@@ -15,14 +17,13 @@ For some inspiration, I like to start with `Who is Batman?` then work from there
 Batman's top 10 enemies are, or what was the most creative way Batman saved the day? Some example responses to those questions are below.
 
 !! note
-    If you treat the LLM like a knowledge repository, you can get a lot of useful information out of it. But remember not to
+    If you treat the LLM like a knowledge repository, you can get a lot of useful information out of it. But, remember not to
     blindly accept its output. You should always cross-reference important things. Treat it like a confident librarian! They've read
     a lot and they can be very fast at finding books, but they can mix things up too!
 
-## Example Output using the `ollama` CLI
+## Using the `ollama` CLI
 
 This is an example of of using the CLI with vanilla ollama:
-
 
 ```
 $ ollama run granite3.1-dense
@@ -99,8 +100,8 @@ good - all hallmarks of his character. The innovative approach to saving the day
 in Batman's extensive history.
 ```
 
-## Try it Yourself
+## Conclusion
 
-Spend some time asking your LLM about anything about any topic and exploring how you can alter its output to provide you with more interesting or satisfying responses.
+Spend as much time as you want asking your LLM about anything about any topic and exploring how you can alter its output to provide you with more interesting or satisfying responses.
 
 When you feel acquainted with your model, move on to [Lab 3](/docs/lab-3/README.md) to learn about Prompt Engineering.

--- a/docs/lab-3/README.md
+++ b/docs/lab-3/README.md
@@ -4,17 +4,13 @@ description: Learn about prompt engineering techniques
 logo: images/ibm-blue-background.png
 ---
 
-!!! note
-    This lab was informed by [@juliandiscovers](https://www.youtube.com/channel/UCXKuHxwAeZZu_dg_qs8Z-9w) and [@BenzaMaman](https://www.instagram.com/benzamaman/)'s workshops and content and presents a broad overview of what they teach. If you want to dive deeper into Prompt Engineering we recommend checking them out.
-
 ## What is Prompt Engineering (PE)?
 
 Prompt engineering is the practice of designing clear, intentional instructions to guide the behavior of an AI model.
 
-It involves crafting prompts—usually in natural language—that help a model identify what task to perform, how to perform it, and if there are considerations in style or format.
-This can include specifying tone, structure, context, or even assigning the AI a particular role.
-Prompt engineering is essential because the quality and precision of the prompt can significantly influence the quality, relevance, and creativity of the generated output.
-As generative models become more powerful, skillful prompting becomes a key tool for unlocking their full potential.
+It involves crafting prompts that help a model identify what task to perform, how to perform it, and if there are considerations in style or format. This can include specifying tone, structure, context, or even assigning the AI a particular role.
+
+Prompt engineering is essential because the quality and precision of the prompt can significantly influence the quality, relevance, and creativity of the generated output. As generative models become more powerful, skillful prompting becomes a key tool for unlocking their full potential.
 
 ### The Three Key Principles of PE
 
@@ -105,7 +101,6 @@ to be repaired and we should be able to reach out in a couple weeks.
 
 So much better! By providing more context and more insight into what you are expecting in a response, we can improve the quality of our responses greatly. Also, by providing **multiple** examples, you're achieving *multi-shot prompting*!.
 
-Let's move on to the next lab and apply what you've learned with some exercises.
+## Conclusion
 
-!!! tip
-    You could even use `ollama`'s CLI in a terminal to interact with your model by using `ollama run granite3.1-dense`
+Now that you know the basics of prompt engineering and simple techniques you can use to level-up your prompts, let's move on to [Lab 4](/docs/lab-4/README.md) and apply what you've learned with some exercises.

--- a/docs/lab-3/README.md
+++ b/docs/lab-3/README.md
@@ -103,4 +103,4 @@ So much better! By providing more context and more insight into what you are exp
 
 ## Conclusion
 
-Now that you know the basics of prompt engineering and simple techniques you can use to level-up your prompts, let's move on to [Lab 4](/docs/lab-4/README.md) and apply what you've learned with some exercises.
+Now that you know the basics of prompt engineering and simple techniques you can use to level-up your prompts, let's move on to [Lab 4](https://ibm.github.io/opensource-ai-workshop/lab-4/) and apply what you've learned with some exercises.

--- a/docs/lab-3/README.md
+++ b/docs/lab-3/README.md
@@ -4,6 +4,9 @@ description: Learn about prompt engineering techniques
 logo: images/ibm-blue-background.png
 ---
 
+!!! note
+    This lab was informed by [@juliandiscovers](https://www.youtube.com/channel/UCXKuHxwAeZZu_dg_qs8Z-9w) and [@BenzaMaman](https://www.instagram.com/benzamaman/)'s workshops and content and presents a broad overview of what they teach. If you want to dive deeper into Prompt Engineering we recommend checking them out.
+
 ## What is Prompt Engineering (PE)?
 
 Prompt engineering is the practice of designing clear, intentional instructions to guide the behavior of an AI model.

--- a/docs/lab-4/README.md
+++ b/docs/lab-4/README.md
@@ -4,11 +4,11 @@ description: Refine your prompting skills
 logo: images/ibm-blue-background.png
 ---
 
-Complete the following exercises using your local LLM.
+Complete the following exercises using your local LLM. Try to come up with your own prompts from scratch! Take note of what works and what doesn't.
 
 - **Be curious!** What if you ask the same question but in a different way, does the response significantly change?
 - **Be creative!** Do you want the response to be organized in a numbered or bulleted list instead of sentences?
-- **Be specific!** Aim for perfection. Use descriptive language, examples, and parameters to perfect your output.
+- **Be specific!** Aim for perfection. Use descriptive language and examples to perfect your output.
 
 !!! note
     Discovered something cool or unexpected? Don’t keep it to yourself, raise your hand or let the TA know!
@@ -209,3 +209,7 @@ all designed to be completed in a single session of gameplay
 
 The best part of this prompt is that you can take the output and extend or shorten the portions it starts with, and tailor the story to your adventurers' needs!
 </details>
+
+## Conclusion
+
+Well done! By completing these exercises, you're well on your way to being a prompt expert. In [Lab 5](/docs/lab-5/README.md), we'll move towards code-generation and learn how to use a local coding assistant.

--- a/docs/lab-4/README.md
+++ b/docs/lab-4/README.md
@@ -212,4 +212,4 @@ The best part of this prompt is that you can take the output and extend or short
 
 ## Conclusion
 
-Well done! By completing these exercises, you're well on your way to being a prompt expert. In [Lab 5](/docs/lab-5/README.md), we'll move towards code-generation and learn how to use a local coding assistant.
+Well done! By completing these exercises, you're well on your way to being a prompt expert. In [Lab 5](https://ibm.github.io/opensource-ai-workshop/lab-5/), we'll move towards code-generation and learn how to use a local coding assistant.

--- a/docs/lab-5/README.md
+++ b/docs/lab-5/README.md
@@ -69,7 +69,6 @@ For inline code suggestions, it's generally recommended that you use smaller mod
 
 Now that you have everything configured in VSCode, let's make sure that it works. Ensure that `ollama` is running in the background either as a status bar item or in the terminal using `ollama serve`.
 
-
 Open the Continue exension and test your local assistant.
 
 ```text
@@ -77,3 +76,7 @@ What language is popular for backend development?
 ```
 
 Additionally, if you open a file for editing you should see possible tab completions to the right of your cursor (it may take a few seconds to show up).
+
+## Conclusion
+
+With your AI coding assistant set up, move on to [Lab 6](/docs/lab-6/README.md) and actually use it!

--- a/docs/lab-5/README.md
+++ b/docs/lab-5/README.md
@@ -79,4 +79,4 @@ Additionally, if you open a file for editing you should see possible tab complet
 
 ## Conclusion
 
-With your AI coding assistant set up, move on to [Lab 6](/docs/lab-6/README.md) and actually use it!
+With your AI coding assistant now set up, move on to [Lab 6](https://ibm.github.io/opensource-ai-workshop/lab-6/) and actually use it!

--- a/docs/lab-6/README.md
+++ b/docs/lab-6/README.md
@@ -111,4 +111,4 @@ Continue also provides the ability to automatically add comments to code. Try it
 
 ## Conclusion
 
-This lab was all about using our local, open-source AI co-pilot to write complex code in Python. By combining Continue and Granite-Code we were able to generate code, the model to explain functions, write tests, and add comments to our code.
+This lab was all about using our local, open-source AI co-pilot to write complex code in Python. By combining Continue and Granite-Code, we were able to generate code, explain functions, write tests, and add comments to our code!

--- a/docs/lab-6/README.md
+++ b/docs/lab-6/README.md
@@ -36,7 +36,7 @@ Write the code for conway's game of life using pygame
 !!! note
     [What is Conway's Game of Life?](https://en.wikipedia.org/wiki/Conway's_Game_of_Life)
 
-After a few moments, the mode should start writing code in the file, it might look something like:
+After a few moments, the model should start writing code in the file, it might look something like:
 ![gameoflife_v1](../images/gameoflife_v1.png)
 
 ## AI-Generated Code
@@ -56,7 +56,7 @@ At this point, you can practice debugging or refactoring code with the AI co-pil
     In the example generated code, a "main" entry point to the script is missing. In this case, using `cmd+I` again and trying the prompt: "write a main function for my game that plays ten rounds of Conway's
     game of life using the `board()` function." might help. What happens?
 
-It's hard to read the generated case in the example case, making it hard to read the logic. To clean it up, I'll define a `main` function so the entry point exists. There was also a `tkinter` section in the generated code, I decided to put the main game loop there:
+It's hard to read the generated code in the example case, making it difficult to understand the logic. To clean it up, I'll define a `main` function so the entry point exists. There's also a `tkinter` section in the generated code, I decided to put the main game loop there:
 
 ```python
 if __name__ == '__main__':
@@ -78,7 +78,7 @@ It looks like the code is improving:
 
 ## Explaining the Code
 
-To debug further, use Granite-Code to explain what the different functions do. Simply highlight one of them, and use `cmd+L` to add it to the context window of your assistant and write a prompt similar to:
+To debug further, use Granite-Code to explain what the different functions do. Simply highlight one of them, use `cmd+L` to add it to the context window of your assistant and write a prompt similar to:
 
 ```text
 what does this function do?
@@ -98,24 +98,17 @@ Assuming you still have a function you wanted explained above in the context-win
 write a pytest test for this function
 ```
 
-Now I got a good framework for a test here:
+The model generated a great framework for a test here:
 ![lazy pytest](../images/pytest_test.png)
 
-Notice that my test only spans what is provided in the context, so the test isn't integrated into my project yet. But, the code provides a good start. I'll need to create a new test file and integrate `pytest` into my project.
+Notice that the test only spans what is provided in the context, so it isn't integrated into my project yet. But, the code provides a good start. I'll need to create a new test file and integrate `pytest` into my project to use it.
 
 ## Adding Comments
 
-Continue also provides the ability to automatically add comments to code:
+Continue also provides the ability to automatically add comments to code. Try it out!
 
 ![comment_code](../images/comment_code.png)
 
-
 ## Conclusion
 
-
-!!! success
-    Thank you SO MUCH for joining us on this workshop, if you have any thoughts or questions
-    the TAs would love answer them for you. If you found any issues or bugs, don't hesitate
-    to put a [Pull Request](https://github.com/IBM/opensource-ai-workshop/pulls) or an
-    [Issue](https://github.com/IBM/opensource-ai-workshop/issues/new) in and we'll get to it
-    ASAP.
+This lab was all about using our local, open-source AI co-pilot to write complex code in Python. By combining Continue and Granite-Code we were able to generate code, the model to explain functions, write tests, and add comments to our code.

--- a/docs/pre-work/README.md
+++ b/docs/pre-work/README.md
@@ -96,6 +96,6 @@ pip install open-webui
 open-webui serve
 ```
 
-Now that you have all of the tools you need, let's start building our local AI co-pilot.
+## Conclusion
 
-**Head over to [Lab 1](/docs/lab-1/README.md) if you have AnythingLLM or [Lab 1.5](/docs/lab-1.5/README.md) for Open-WebUI.**
+Now that you have all of the tools you need, head over to [Lab 1](https://ibm.github.io/opensource-ai-workshop/lab-1/) if you have AnythingLLM or [Lab 1.5](https://ibm.github.io/opensource-ai-workshop/lab-1.5/) for Open-WebUI.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,9 +21,6 @@ nav:
     - Lab 4. Applying What You Learned: lab-4/README.md
     - Lab 5. Configuring an AI Co-pilot: lab-5/README.md
     - Lab 6. Coding with an AI Co-pilot: lab-6/README.md
-  - References:
-    - Additional Resources: resources/RESOURCES.md
-    - MkDocs Cheatsheet: resources/MKDOCS.md
 
 ## DO NOT CHANGE BELOW THIS LINE
 


### PR DESCRIPTION
- Fixes typos 
- Fixes links that lead to the next lab
- Adds conclusion headers to each lab
- Removes "References" tab on workshop with unrelated resources https://ibm.github.io/opensource-ai-workshop/resources/RESOURCES/