### PR TITLE
Adding copy, footer, lab7 items

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,7 @@ Our overarching goals of this workshop is as follows:
 | [Lab 4: Applying What You Learned](lab-4/README.md) | Refine your prompting skills |
 | [Lab 5: Building a local AI Assistant](lab-5/README.md) | Build a Granite coding assistant |
 | [Lab 6: Coding with an AI Assistant](lab-6/README.md) | Write code using Continue and Granite |
+| [Lab 7: Using Mellea to help with Generative Computing](lab-7/README.md) | Learn how to leverage Mellea for Advanced AI situations |
 
 Thank you SO MUCH for joining us in this workshop! If you have any questions or feedback,
 the TAs would love answer them for you. If you come across any issues or bugs, don't hesitate

--- a/docs/lab-7/README.md
+++ b/docs/lab-7/README.md
@@ -55,7 +55,7 @@ and brittle prompts with structured, maintainable, robust, and efficient AI work
 
 ## Let's setup Mellea to work locally
 
-1. Open up a terminal, and run the following commands:
+1.  Open up a terminal, and run the following commands:
 ```bash
 python3.11 -m venv venv
 source venv/bin/activate
@@ -65,7 +65,12 @@ pip install mellea
 !!! note
     If you see something about the Rust compiler, please confirm you are using python3.11, or python3.12 anything above that has a Rust dependency.
 
-2. Run a simple Mellea session:
+1.  Start python:
+```bash
+python
+```
+
+1.  Run a simple Mellea session:
 ```python
 import mellea
 
@@ -75,12 +80,15 @@ print(m.chat("What is the etymology of mellea?").content)
 You can either add this to a file like `main.py` or run it in the python REPL, if you get output
 you are set up to dig deeper with Mellea.
 
+!!! note
+    If you see an error message with: "ModuleNotFoundError: No module named 'PIL'" then you will need to install the python package pillow with "pip install pillow"
+
 ## Simple email examples
 
 !!! note
     The following work should be done via a text editor, there should be a couple installed on your laptop, if you aren't sure raise your hand and a helper will help you out.
 
-Let's leverage Mellea to do some email generation for us, the first example is a simple example:
+1.  Let's leverage Mellea to do some email generation for us, the first example is a simple example:
 ```python
 import mellea
 m = mellea.start_session()
@@ -88,7 +96,8 @@ m = mellea.start_session()
 email = m.instruct("Write an email inviting interns to an office party at 3:30pm.")
 print(str(email))
 ```
-As you can see, it outputs a standard email with only a couple lines of code, lets expand on this:
+
+1.  As you can see, it outputs a standard email with only a couple lines of code, lets expand on this:
 ```python
 import mellea
 m = mellea.start_session()
@@ -114,7 +123,7 @@ Mellea really shines.
 
 ### Simple email with boundries and requirements
 
-The first step with the power of Mellea, is adding requirements to something like this email, take a look at this first
+1. The first step with the power of Mellea, is adding requirements to something like this email, take a look at this first
 example:
 ```python
 import mellea
@@ -152,7 +161,7 @@ Let's create an email with some sampling and have Mellea, find the best option f
 We add two requirements to the instruction which will be added to the model request.
 But we don't check yet if these requirements are satisfied, we add a strategy for validating the requirements.
 
-This sampling strategy (`RejectionSamplingStrategy()`) checks if all requirements are met and if any requirement fails, the sampling strategy will sample a new email from the LLM.
+1. This sampling strategy (`RejectionSamplingStrategy()`) checks if all requirements are met and if any requirement fails, the sampling strategy will sample a new email from the LLM.
 ```python
 import mellea
 m = mellea.start_session()
@@ -192,7 +201,7 @@ writing you expect is within the boundaries and it'll keep trying till it gets i
 
 ## Instruct Validate Repair
 
-The first `instruct-validate-repair` pattern is as follows:
+1. The first `instruct-validate-repair` pattern is as follows:
 
 ```python
 import mellea

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,7 +26,7 @@ nav:
 ## DO NOT CHANGE BELOW THIS LINE
 
 # Copyright
-copyright: Copyright &copy; 2024- IBM Research
+copyright: Copyright &copy; 2025- IBM Research
 
 # Theme
 theme:
@@ -40,7 +40,10 @@ theme:
   favicon: images/favicon.ico
   features:
     - navigation.tabs
+    - navigation.footer
     #- navigation.instant
+    - content.code.copy
+    - content.tabs.link
   palette:
     scheme: default
     primary: blue


### PR DESCRIPTION
I added the following:

1.  feature to allow copy and paste from the generated page with:
```
    - content.code.copy
```
2. feature to allow the footer to show at the bottom for easier page navigation
```
    - navigation.footer
```
3. I added the lab-7 to the base Readme so it's visible in the agenda

4. I added a python step, and also a note about the missing pillow dependency.  (Hopefully we can remove this soon.)